### PR TITLE
elasticsearch-create-backup-repository.sh: Fix verbosity of curl

### DIFF
--- a/templates/elasticsearch/elasticsearch-create-backup-repository.sh.j2
+++ b/templates/elasticsearch/elasticsearch-create-backup-repository.sh.j2
@@ -2,5 +2,5 @@
 
 # This file is handled by ansible
 
-curl --fail -XPUT "http://{{ backup_es_host }}:{{ backup_es_port }}/_snapshot/{{ backup_es_repository_name }}" -d '{{ _es_create_repository_body | to_nice_json }}'
+curl --silent --show-error --fail -XPUT "http://{{ backup_es_host }}:{{ backup_es_port }}/_snapshot/{{ backup_es_repository_name }}" -d '{{ _es_create_repository_body | to_nice_json }}'
 exit $?


### PR DESCRIPTION
Curl was to verbose, so even when succeeding the cron would send us an
email to inform us. That is unecessary and also spam for no apparent
reasons. After applying this commit, the crons of ES backups should
notify us only when something wrong happened - which is the expected
behavior.
