### PR TITLE
awscli: let the system resolv the path of the tool

### DIFF
--- a/tasks/mongodb/validate.yml
+++ b/tasks/mongodb/validate.yml
@@ -13,21 +13,21 @@
 
 # Use command instead of s3 module was made to test exactly the command that the cron will execute
 - name: Validate the cron user can push into the bucket with s3cmd
-  command: /usr/local/bin/aws s3 cp /tmp/ansible-backup-mongo.test s3://{{ backup_mongo_bucket_name }}
+  command: aws s3 cp /tmp/ansible-backup-mongo.test s3://{{ backup_mongo_bucket_name }}
   become: yes
   become_user: "{{ backup_mongo_cron_user }}"
   environment:
     HOME: "{{ user_home.stdout }}"
 
 - name: Validate the file is uploaded
-  command: /usr/local/bin/aws s3 ls s3://{{ backup_mongo_bucket_name }}/ansible-backup-mongo.test
+  command: aws s3 ls s3://{{ backup_mongo_bucket_name }}/ansible-backup-mongo.test
   become: yes
   become_user: "{{ backup_mongo_cron_user }}"
   environment:
     HOME: "{{ user_home.stdout }}"
 
 - name: Validate cleanup test file in s3
-  command: /usr/local/bin/aws s3 rm s3://{{ backup_mongo_bucket_name }}/ansible-backup-mongo.test
+  command: aws s3 rm s3://{{ backup_mongo_bucket_name }}/ansible-backup-mongo.test
   become: yes
   become_user: "{{ backup_mongo_cron_user }}"
   environment:

--- a/tasks/mysql/validate.yml
+++ b/tasks/mysql/validate.yml
@@ -13,21 +13,21 @@
 
 # Use command instead of s3 module was made to test exactly the command that the cron will execute
 - name: Validate the cron user can push into the bucket with s3cmd
-  command: /usr/local/bin/aws s3 cp /tmp/ansible-backup-postgresql.test s3://{{ backup_postgresql_bucket_name }}
+  command: aws s3 cp /tmp/ansible-backup-postgresql.test s3://{{ backup_postgresql_bucket_name }}
   become: yes
   become_user: "{{ backup_postgresql_cron_user }}"
   environment:
     HOME: "{{ user_home.stdout }}"
 
 - name: Validate the file is uploaded
-  command: /usr/local/bin/aws s3 ls s3://{{ backup_postgresql_bucket_name }}/ansible-backup-postgresql.test
+  command: aws s3 ls s3://{{ backup_postgresql_bucket_name }}/ansible-backup-postgresql.test
   become: yes
   become_user: "{{ backup_postgresql_cron_user }}"
   environment:
     HOME: "{{ user_home.stdout }}"
 
 - name: Validate cleanup test file in s3
-  command: /usr/local/bin/aws s3 rm s3://{{ backup_postgresql_bucket_name }}/ansible-backup-postgresql.test
+  command: aws s3 rm s3://{{ backup_postgresql_bucket_name }}/ansible-backup-postgresql.test
   become: yes
   become_user: "{{ backup_postgresql_cron_user }}"
   environment:

--- a/tasks/postgresql/validate.yml
+++ b/tasks/postgresql/validate.yml
@@ -14,21 +14,21 @@
 
 # Use command instead of s3 module was made to test exactly the command that the cron will execute
 - name: Validate the cron user can push into the bucket with s3cmd
-  command: /usr/local/bin/aws s3 cp /tmp/ansible-backup-postgresql.test s3://{{ backup_postgresql_bucket_name }}
+  command: aws s3 cp /tmp/ansible-backup-postgresql.test s3://{{ backup_postgresql_bucket_name }}
   become: yes
   become_user: "{{ backup_postgresql_cron_user }}"
   environment:
     HOME: "{{ user_home.stdout }}"
 
 - name: Validate the file is uploaded
-  command: /usr/local/bin/aws s3 ls s3://{{ backup_postgresql_bucket_name }}/ansible-backup-postgresql.test
+  command: aws s3 ls s3://{{ backup_postgresql_bucket_name }}/ansible-backup-postgresql.test
   become: yes
   become_user: "{{ backup_postgresql_cron_user }}"
   environment:
     HOME: "{{ user_home.stdout }}"
 
 - name: Validate cleanup test file in s3
-  command: /usr/local/bin/aws s3 rm s3://{{ backup_postgresql_bucket_name }}/ansible-backup-postgresql.test
+  command: aws s3 rm s3://{{ backup_postgresql_bucket_name }}/ansible-backup-postgresql.test
   become: yes
   become_user: "{{ backup_postgresql_cron_user }}"
   environment:

--- a/templates/mongodb/mongo-backup.sh.j2
+++ b/templates/mongodb/mongo-backup.sh.j2
@@ -57,7 +57,7 @@ rm -rf {{ backup_mongo_local_path }}
 
 # Upload to S3
 do_log "Upload file on s3 s3://{{ backup_mongo_bucket_name }}/{{ backup_mongo_s3_path }}/$TAR_FILE"
-/usr/local/bin/aws s3 cp /tmp/$TAR_FILE  s3://{{ backup_mongo_bucket_name }}/{{ backup_mongo_s3_path }}/$TAR_FILE
+aws s3 cp /tmp/$TAR_FILE  s3://{{ backup_mongo_bucket_name }}/{{ backup_mongo_s3_path }}/$TAR_FILE
 
 UPLOAD_STATUS=$?
 

--- a/templates/mongodb/mongo-restore.sh.j2
+++ b/templates/mongodb/mongo-restore.sh.j2
@@ -50,8 +50,8 @@ then
 fi
 
 do_log "Retrieve the backup archive in {{ backup_mongo_local_path }}"
-S3_FILENAME="$(/usr/local/bin/aws s3 ls s3://{{ backup_mongo_bucket_name }}/$PROJECT/mongodb/$ENV/ | grep "$FILTER" | sort | tail -n1 | awk '{print $4}')"
-/usr/local/bin/aws s3 cp --quiet s3://{{ backup_mongo_bucket_name }}/$PROJECT/mongodb/$ENV/$S3_FILENAME {{ backup_mongo_local_path }}/mongodb-$ENV-backup.tar.gz
+S3_FILENAME="$(aws s3 ls s3://{{ backup_mongo_bucket_name }}/$PROJECT/mongodb/$ENV/ | grep "$FILTER" | sort | tail -n1 | awk '{print $4}')"
+aws s3 cp --quiet s3://{{ backup_mongo_bucket_name }}/$PROJECT/mongodb/$ENV/$S3_FILENAME {{ backup_mongo_local_path }}/mongodb-$ENV-backup.tar.gz
 tar -zxvf -C {{ backup_mongo_local_path }} {{ backup_mongo_local_path }}/mongodb-$ENV-backup.tar.gz
 i
 

--- a/templates/mysql/mysql-backup.sh.j2
+++ b/templates/mysql/mysql-backup.sh.j2
@@ -47,7 +47,7 @@ rm -rf {{ backup_mysql_local_path }}
 
 # Upload to S3
 do_log "Upload file on s3 s3://{{ backup_mysql_bucket_name }}/{{ backup_mysql_s3_path }}/$TAR_FILE"
-/usr/local/bin/aws s3 cp /tmp/$TAR_FILE  s3://{{ backup_mysql_bucket_name }}/{{ backup_mysql_s3_path }}/$TAR_FILE
+aws s3 cp /tmp/$TAR_FILE  s3://{{ backup_mysql_bucket_name }}/{{ backup_mysql_s3_path }}/$TAR_FILE
 
 UPLOAD_STATUS=$?
 

--- a/templates/postgresql/postgresql-backup.sh.j2
+++ b/templates/postgresql/postgresql-backup.sh.j2
@@ -61,7 +61,7 @@ rm -rf {{ backup_postgresql_local_path }}
 
 # Upload to S3
 do_log "Upload file on s3 s3://{{ backup_postgresql_bucket_name }}/{{ backup_postgresql_s3_path }}/$TAR_FILE"
-/usr/local/bin/aws s3 cp /tmp/$TAR_FILE  s3://{{ backup_postgresql_bucket_name }}/{{ backup_postgresql_s3_path }}/$TAR_FILE
+aws s3 cp /tmp/$TAR_FILE  s3://{{ backup_postgresql_bucket_name }}/{{ backup_postgresql_s3_path }}/$TAR_FILE
 
 UPLOAD_STATUS=$?
 


### PR DESCRIPTION
The `awscli` tool is not necessary installed in `/usr/local/bin`.

The role checks if the command is available with the `which` command and
install it with `pip` if it isn't which will end up in `/usr/local/bin`.

But if the tool is installed via a package, it might end up in `/usr/bin`.